### PR TITLE
Adding a event_delivery_preference of BOTH to unblock fleet

### DIFF
--- a/provider/oauth2/models.py
+++ b/provider/oauth2/models.py
@@ -47,7 +47,7 @@ class EventDeliveryPreference:
         (WEBHOOK, 'WEBHOOK'),
         (WEBSOCKET, 'WEBSOCKET'),
         (WEBHOOK_FIXED_IP, 'WEBHOOK_FIXED_IP'),
-        (BOTH, 'BOTH'),
+        (BOTH, 'BOTH - ONLY FOR FLEET. DO NOT USE'),
     )
 
 class ScopeField(models.IntegerField):

--- a/provider/oauth2/models.py
+++ b/provider/oauth2/models.py
@@ -40,12 +40,14 @@ class EventDeliveryPreference:
     WEBHOOK = 1
     WEBSOCKET = 2
     WEBHOOK_FIXED_IP = 3
+    BOTH = 4
 
     CHOICES = (
         (NONE, 'NONE'),
         (WEBHOOK, 'WEBHOOK'),
         (WEBSOCKET, 'WEBSOCKET'),
         (WEBHOOK_FIXED_IP, 'WEBHOOK_FIXED_IP'),
+        (BOTH, 'BOTH'),
     )
 
 class ScopeField(models.IntegerField):


### PR DESCRIPTION
Fleet uses both websockets and webhooks. This was not properly communicated when we decided to move to a single event_delivery_preference. Adding a preference of `BOTH` here to unbreak fleet. Not asking them to make any changes now since they are going to be moving over to Hedwig anyway. 
